### PR TITLE
Fixing NPE with proper exception when getType is null

### DIFF
--- a/src/com/kayako/api/ticket/TicketNote.java
+++ b/src/com/kayako/api/ticket/TicketNote.java
@@ -785,14 +785,23 @@ public class TicketNote extends KEntity {
             throw new KayakoException();
         }
         this.setType(TicketNoteTypeEnum.getEnum(element.getAttribute("type"))).setId(Helper.parseInt(element.getAttribute("id")));
-        if (this.getType().equals(TicketNoteTypeEnum.TICKET)) {
-            this.setTicketId(Helper.parseInt(element.getAttribute("ticketid")));
-        } else if (this.getType().equals(TicketNoteTypeEnum.USER)) {
-            this.setUserId(Helper.parseInt(element.getAttribute("userid")));
-        } else if (this.getType().equals(TicketNoteTypeEnum.USER_ORGANIZATION)) {
-            this.setUserOrganizationId(Helper.parseInt(element.getAttribute("userorganizationid")));
+        if (this.getType() == null) {
+		throw new KayakoException("Ticket has invalid/missing type");
+	}
+	switch (this.getType()) {
+            case TICKET:
+                this.setTicketId(Helper.parseInt(element.getAttribute("ticketid")));
+                break;
+            case USER:
+                this.setUserId(Helper.parseInt(element.getAttribute("userid")));
+                break;
+            case USER_ORGANIZATION:
+                this.setUserOrganizationId(Helper.parseInt(element.getAttribute("userorganizationid")));
+                break;
+            default:
+                break;
         }
-        this.setNoteColor(ColorEnum.getEnum(element.getAttribute("notecolor")));
+	this.setNoteColor(ColorEnum.getEnum(element.getAttribute("notecolor")));
         this.setCreatorStaffId(Helper.parseInt(element.getAttribute("creatorstaffid")));
         this.setForStaffId(Helper.parseInt(element.getAttribute("forstaffid")));
         this.setCreatorStaffName(element.getAttribute("creatorstaffname"));


### PR DESCRIPTION
I noticed when getting tickets from our instance that I was getting a null pointer exception on one ticket:

java.lang.NullPointerException
	at com.kayako.api.ticket.TicketNote.populate(Unknown Source)
	at com.kayako.api.ticket.Ticket.populate(Unknown Source)
	at com.kayako.api.ticket.Ticket.refineToArray(Unknown Source)
	at com.kayako.api.ticket.Ticket.search(Unknown Source)

This patch corrects the NPE to be a proper KayakoException with a useful error message:

com.kayako.api.exception.KayakoException: Ticket has invalid/missing type
	at com.kayako.api.ticket.TicketNote.populate(Unknown Source)
	at com.kayako.api.ticket.Ticket.populate(Unknown Source)
	at com.kayako.api.ticket.Ticket.refineToArray(Unknown Source)
	at com.kayako.api.ticket.Ticket.search(Unknown Source)

Still need to investigate the root cause why we have a ticket that causes this state, but at least this patch cleans up the error message and makes it easier to handle.